### PR TITLE
feat: ldap auth & folder CRUD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /target
 .idea
 .DS_Store
+/java-test

--- a/README.md
+++ b/README.md
@@ -79,6 +79,15 @@ The `Auth` component provides methods for authentication:
 ### Universal Auth
 
 #### Authenticating
+
+```java
+public void UniversalAuthLogin(
+  String clientId,
+  String clientSecret
+)
+throws InfisicalException
+```
+
 ```java
 sdk.Auth().UniversalAuthLogin(
   "CLIENT_ID",
@@ -91,9 +100,43 @@ sdk.Auth().UniversalAuthLogin(
 - `clientId` (string): The client ID of your Machine Identity.
 - `clientSecret` (string): The client secret of your Machine Identity.
 
+### LDAP Auth
+
+```java
+public void LdapAuthLogin(
+  LdapAuthLoginInput input
+)
+throws InfisicalException
+```
+
+```java
+var input = LdapAuthLoginInput
+  .builder()
+  .identityId("<machine-identity-id>")
+  .username("<ldap-username>")
+  .password("<ldap-password>")
+  .build();
+
+sdk.Auth().LdapAuthLogin(input);
+```
+
+**Parameters:**
+- `input` (LdapAuthLoginInput): The input for authenticating with LDAP.
+  - `identityId` (String): The ID of the machine identity to authenticate with.
+  - `username` (String): The LDAP username.
+  - `password` (String): The LDAP password.
+
 ### Access Token Auth
 
 #### Authenticating
+
+```java
+public void SetAccessToken(
+  String accessToken
+)
+throws InfisicalException
+```
+
 ```java
 sdk.Auth().SetAccessToken("ACCESS_TOKEN");
 ```
@@ -288,3 +331,152 @@ Secret deletedSecret = sdk.Secrets().DeleteSecret(
 **Returns:**
 - `Secret`: The deleted secret.
 
+
+### `Folders`
+
+#### Get Folder By Name 
+
+```java
+public Folder Get(
+  String folderId
+);
+throws InfisicalException
+```
+
+```java
+Folder folder = sdk.Folders().Get("<folder-id>");
+```
+
+**Parameters:**
+- `folderId` (String): The ID of the folder to retrieve.
+
+**Returns:**
+- `Folder`: The retrieved folder.
+
+#### List Folders
+
+```java
+public List<Folder> List(
+  ListFoldersInput input
+)
+throws InfisicalException
+```
+
+```java
+ListFoldersInput input = ListFoldersInput
+  .builder()
+  .projectId("<your-project-id>")
+  .environmentSlug("<env-slug>")
+  .folderPath("/")
+  .recursive(false)
+  .build();
+
+List<Folder> folders = sdk.Folders().List(input);
+```
+
+
+**Parameters:**
+- `input` (ListFoldersInput): The input for listing folders.
+  - `projectId` (String): The ID of the project to list folders from.
+  - `environmentSlug` (String): The slug of the environment to list folders from.
+  - `folderPath` (String): The path to list folders from. Defaults to `/`.
+  - `recursive` (Boolean): Whether or not to list sub-folders recursively from the specified folder path and downwards. Defaults to `false`.
+
+**Returns:**
+- `List<Folder>`: The retrieved folders.
+
+#### Create Folder
+
+```java
+public Folder Create(
+  CreateFolderInput input
+)
+throws InfisicalException
+```
+
+```java
+var input = CreateFolderInput
+  .builder()
+  .projectId("<your-project-id>")
+  .environmentSlug("<env-slug>")
+  .folderName("<folder-name>")
+  .folderPath("/")
+  .description("Optional folder description")
+  .build();
+
+Folder createdFolder = sdk.Folders().Create(input);
+```
+
+**Parameters:**
+- `input` (CreateFolderInput): The input for creating a folder.
+  - `projectId` (String): The ID of the project to create the folder in.
+  - `environmentSlug` (String): The slug of the environment to create the folder in.
+  - `folderPath` (String): The path to create the folder in. Defaults to `/`.
+  - `folderName` (String): The name of the folder to create.
+  - `description` (String): The description of the folder to create. This is optional.
+
+**Returns:**
+- `Folder`: The created folder.
+
+#### Update Folder
+
+```java
+public Folder Update(
+  UpdateFolderInput input
+)
+throws InfisicalException
+```
+
+```java
+var input = UpdateFolderInput
+  .builder()
+  .projectId("<your-project-id>")
+  .environmentSlug("<env-slug>")
+  .folderId("<id-of-folder-to-update>")
+  .newFolderName("<the-new-folder-name>")
+  .folderPath("/")
+  .build();
+
+Folder updatedFolder = sdk.Folders().Update(input);
+```
+
+**Parameters:**
+- `input` (UpdateFolderInput): The input for updating a folder.
+  - `projectId` (String): The ID of the project where the folder exists.
+  - `environmentSlug` (String): The slug of the environment where the folder exists.
+  - `folderPath` (String): The path of the folder to update.
+  - `folderId` (String): The ID of the folder to update.
+  - `newFolderName` (String): The new folder name.
+
+**Returns:**
+- `Folder`: The updated folder.
+
+#### Delete Folder
+
+```java
+public Folder Delete(
+  DeleteFolderInput input
+)
+throws InfisicalException
+```
+
+```java
+var input = DeleteFolderInput
+  .builder()
+  .folderId("<the-folder-id>")
+  .environmentSlug("<env-slug>")
+  .projectId("<your-project-id>")
+  .build();
+
+Folder deletedFolder = sdk.Folders().Delete(input);
+```
+
+
+**Parameters:**
+- `input` (DeleteFolderInput): The input for deleting a folder.
+  - `projectId` (String): The ID of the project where the folder exists.
+  - `environmentSlug` (String): The slug of the environment where the folder exists.
+  - `folderId` (String): The ID of the folder to delete.
+
+**Returns:**
+- `Folder`: The deleted folder.

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <dependency>
         <groupId>org.projectlombok</groupId>
         <artifactId>lombok</artifactId>
-        <version>1.18.32</version>
+        <version>1.18.30</version>
         <scope>provided</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -55,12 +55,23 @@
     <gson-fire-version>1.8.3</gson-fire-version>
   </properties>
   <dependencies>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.17.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+      <version>2.17.1</version>
+    </dependency>
     <!--    Annotation dependencies-->
     <dependency>
-      <groupId>org.projectlombok</groupId>
-      <artifactId>lombok</artifactId>
-      <version>1.18.30</version>
-      <scope>provided</scope>
+        <groupId>org.projectlombok</groupId>
+        <artifactId>lombok</artifactId>
+        <version>1.18.32</version>
+        <scope>provided</scope>
     </dependency>
 
     <!--    Logging dependencies-->
@@ -128,6 +139,23 @@
       </activation>
       <build>
         <plugins>
+
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.11.0</version>
+            <configuration>
+              <release>21</release>
+              <annotationProcessorPaths>
+                <path>
+                  <groupId>org.projectlombok</groupId>
+                  <artifactId>lombok</artifactId>
+                  <version>1.18.30</version>
+                </path>
+              </annotationProcessorPaths>
+            </configuration>
+          </plugin>
+
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>

--- a/src/main/java/com/infisical/sdk/InfisicalSdk.java
+++ b/src/main/java/com/infisical/sdk/InfisicalSdk.java
@@ -3,6 +3,7 @@ package com.infisical.sdk;
 import com.infisical.sdk.api.ApiClient;
 import com.infisical.sdk.config.SdkConfig;
 import com.infisical.sdk.resources.AuthClient;
+import com.infisical.sdk.resources.FoldersClient;
 import com.infisical.sdk.resources.SecretsClient;
 import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.Request;
@@ -10,6 +11,7 @@ import com.squareup.okhttp.Request;
 
 public class InfisicalSdk {
     private SecretsClient secretsClient;
+    private FoldersClient foldersClient;
     private AuthClient authClient;
 
     private ApiClient apiClient;
@@ -26,14 +28,17 @@ public class InfisicalSdk {
       this.apiClient = new ApiClient(apiClient.GetBaseUrl(), accessToken);
 
       this.secretsClient = new SecretsClient(apiClient);
+      this.foldersClient = new FoldersClient(apiClient);
       this.authClient = new AuthClient(apiClient, this::onAuthenticate);
   }
 
   public AuthClient Auth() {
       return this.authClient;
   }
-
   public SecretsClient Secrets() {
       return this.secretsClient;
+  }
+  public FoldersClient Folders() {
+      return this.foldersClient;
   }
 }

--- a/src/main/java/com/infisical/sdk/api/ApiClient.java
+++ b/src/main/java/com/infisical/sdk/api/ApiClient.java
@@ -107,7 +107,9 @@ public class ApiClient {
         try {
             HttpUrl.Builder urlBuilder = HttpUrl.parse(baseUrl).newBuilder();
 
-            queryParams.forEach(urlBuilder::addQueryParameter);
+            if (queryParams != null) {
+                queryParams.forEach(urlBuilder::addQueryParameter);
+            }
 
             var requestBuilder = new Request.Builder()
                 .url(urlBuilder.build())

--- a/src/main/java/com/infisical/sdk/models/CreateFolderInput.java
+++ b/src/main/java/com/infisical/sdk/models/CreateFolderInput.java
@@ -1,0 +1,47 @@
+package com.infisical.sdk.models;
+
+import com.google.gson.annotations.SerializedName;
+
+import com.infisical.sdk.util.Helper;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class CreateFolderInput {
+  @SerializedName("workspaceId")
+  private String projectId;
+
+  @SerializedName("environment")
+  private String environmentSlug;
+
+  @SerializedName("name")
+  private String folderName;
+
+  @SerializedName("path")
+  private String folderPath;
+
+  @SerializedName("description")
+  private String description;
+
+  public String validate() {
+    if (Helper.isNullOrEmpty(projectId)) {
+      return "Project ID is required";
+    }
+
+    if (Helper.isNullOrEmpty(environmentSlug)) {
+      return "Environment Slug is required";
+    }
+
+    if (Helper.isNullOrEmpty(folderName)) {
+      return "Folder Name is required";
+    }
+
+    if (Helper.isNullOrEmpty(folderPath)) {
+      return "Folder Path is required";
+    }
+
+    return null;
+  }
+
+}

--- a/src/main/java/com/infisical/sdk/models/DeleteFolderInput.java
+++ b/src/main/java/com/infisical/sdk/models/DeleteFolderInput.java
@@ -1,0 +1,42 @@
+package com.infisical.sdk.models;
+
+import com.google.gson.annotations.SerializedName;
+import com.infisical.sdk.util.Helper;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class DeleteFolderInput {
+  @SerializedName("workspaceId")
+  private String projectId;
+
+  @SerializedName("environment")
+  private String environmentSlug;
+
+  @SerializedName("folderId")
+  private String folderId;
+
+  @SerializedName("path")
+  @Builder.Default private String folderPath = "/";
+
+  public String validate() {
+    if (Helper.isNullOrEmpty(projectId)) {
+      return "Project ID is required";
+    }
+
+    if (Helper.isNullOrEmpty(environmentSlug)) {
+      return "Environment Slug is required";
+    }
+
+    if (Helper.isNullOrEmpty(folderId)) {
+      return "Folder ID is required";
+    }
+
+    if (Helper.isNullOrEmpty(folderPath)) {
+      return "Folder Path is required";
+    }
+
+    return null;
+  }
+}

--- a/src/main/java/com/infisical/sdk/models/Folder.java
+++ b/src/main/java/com/infisical/sdk/models/Folder.java
@@ -1,0 +1,40 @@
+package com.infisical.sdk.models;
+
+import com.google.gson.annotations.SerializedName;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+public class Folder {
+  @SerializedName("id")
+  private String id;
+
+  @SerializedName("name")
+  private String name;
+
+  @SerializedName("version")
+  private String version;
+
+  @SerializedName("createdAt")
+  private String createdAt;
+
+  @SerializedName("updatedAt")
+  private String updatedAt;
+
+  @SerializedName("envId")
+  private String environmentId;
+
+  @SerializedName("parentId")
+  private String parentId;
+
+  @SerializedName("isReserved")
+  private boolean isReserved;
+
+  @SerializedName("description")
+  private String description;
+
+  @SerializedName("lastSecretModified")
+  private String lastSecretModified;
+
+}

--- a/src/main/java/com/infisical/sdk/models/Folder.java
+++ b/src/main/java/com/infisical/sdk/models/Folder.java
@@ -1,8 +1,6 @@
 package com.infisical.sdk.models;
 
 import com.google.gson.annotations.SerializedName;
-
-import lombok.Builder;
 import lombok.Data;
 
 @Data

--- a/src/main/java/com/infisical/sdk/models/LdapAuthLoginInput.java
+++ b/src/main/java/com/infisical/sdk/models/LdapAuthLoginInput.java
@@ -1,0 +1,30 @@
+package com.infisical.sdk.models;
+
+
+import com.infisical.sdk.util.Helper;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class LdapAuthLoginInput {
+    private String identityId;
+    private String username;
+    private String password;
+
+    public String validate() {
+        if (Helper.isNullOrEmpty(identityId)) {
+            return "Identity ID is required";
+        }
+
+        if (Helper.isNullOrEmpty(username)) {
+            return "Username is required";
+        }
+
+        if (Helper.isNullOrEmpty(password)) {
+            return "Password is required";
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/infisical/sdk/models/ListFoldersInput.java
+++ b/src/main/java/com/infisical/sdk/models/ListFoldersInput.java
@@ -1,0 +1,39 @@
+package com.infisical.sdk.models;
+
+import com.google.gson.annotations.SerializedName;
+
+import com.infisical.sdk.util.Helper;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ListFoldersInput {
+  @SerializedName("workspaceId")
+  private String projectId;
+
+  @SerializedName("environment")
+  private String environmentSlug;
+
+  @SerializedName("path")
+  @Builder.Default private String folderPath = "/";
+
+  @SerializedName("recursive")
+  private Boolean recursive;
+
+  public String validate() {
+    if (Helper.isNullOrEmpty(projectId)) {
+      return "Project ID is required";
+    }
+
+    if (Helper.isNullOrEmpty(environmentSlug)) {
+      return "Environment Slug is required";
+    }
+
+    if (Helper.isNullOrEmpty(folderPath)) {
+      return "Folder Path is required";
+    }
+
+    return null;
+  }
+}

--- a/src/main/java/com/infisical/sdk/models/ListFoldersResponse.java
+++ b/src/main/java/com/infisical/sdk/models/ListFoldersResponse.java
@@ -1,0 +1,14 @@
+package com.infisical.sdk.models;
+
+import java.util.List;
+
+import com.google.gson.annotations.SerializedName;
+
+public class ListFoldersResponse {
+  @SerializedName("folders")
+  private List<Folder> folders;
+
+  public List<Folder> getFolders() {
+    return folders;
+  }
+}

--- a/src/main/java/com/infisical/sdk/models/SingleFolderResponse.java
+++ b/src/main/java/com/infisical/sdk/models/SingleFolderResponse.java
@@ -1,0 +1,13 @@
+package com.infisical.sdk.models;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Getter;
+
+public class SingleFolderResponse {
+  @SerializedName("folder")
+  private Folder folder;
+
+  public Folder getFolder() {
+    return folder;
+  }
+}

--- a/src/main/java/com/infisical/sdk/models/SingleFolderResponse.java
+++ b/src/main/java/com/infisical/sdk/models/SingleFolderResponse.java
@@ -1,7 +1,6 @@
 package com.infisical.sdk.models;
 
 import com.google.gson.annotations.SerializedName;
-import lombok.Getter;
 
 public class SingleFolderResponse {
   @SerializedName("folder")

--- a/src/main/java/com/infisical/sdk/models/UpdateFolderInput.java
+++ b/src/main/java/com/infisical/sdk/models/UpdateFolderInput.java
@@ -1,0 +1,50 @@
+package com.infisical.sdk.models;
+
+import com.google.gson.annotations.SerializedName;
+import com.infisical.sdk.util.Helper;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class UpdateFolderInput {
+  @SerializedName("workspaceId")
+  private String projectId;
+
+  @SerializedName("environment")
+  private String environmentSlug;
+
+  @SerializedName("folderId")
+  private String folderId;
+
+  @SerializedName("path")
+  @Builder.Default private String folderPath = "/";
+
+  @SerializedName("name")
+  private String newFolderName;
+
+
+  public String validate() {
+    if (Helper.isNullOrEmpty(projectId)) {
+      return "Project ID is required";
+    }
+
+    if (Helper.isNullOrEmpty(environmentSlug)) {
+      return "Environment Slug is required";
+    }
+
+    if (Helper.isNullOrEmpty(folderId)) {
+      return "Folder ID is required";
+    }
+
+    if (Helper.isNullOrEmpty(folderPath)) {
+      return "Folder Path is required";
+    }
+
+    if (Helper.isNullOrEmpty(newFolderName)) {
+      newFolderName = null;
+    }
+
+    return null;
+  }
+}

--- a/src/main/java/com/infisical/sdk/resources/AuthClient.java
+++ b/src/main/java/com/infisical/sdk/resources/AuthClient.java
@@ -1,5 +1,6 @@
 package com.infisical.sdk.resources;
 
+import com.infisical.sdk.models.LdapAuthLoginInput;
 import com.infisical.sdk.models.MachineIdentityCredential;
 import com.infisical.sdk.util.InfisicalException;
 import java.util.function.Consumer;
@@ -24,6 +25,18 @@ public class AuthClient {
 
       var url = String.format("%s%s", this.apiClient.GetBaseUrl(), "/api/v1/auth/universal-auth/login");
       var credential = this.apiClient.post(url, params, MachineIdentityCredential.class);
+      this.onAuthenticate.accept(credential.getAccessToken());
+  }
+
+  public void LdapAuthLogin(LdapAuthLoginInput input) throws InfisicalException {
+      var validationMsg = input.validate();
+
+      if (validationMsg != null) {
+          throw  new InfisicalException(validationMsg);
+      }
+
+      var url = String.format("%s%s", this.apiClient.GetBaseUrl(), "/api/v1/auth/ldap-auth/login");
+      var credential = this.apiClient.post(url, input, MachineIdentityCredential.class);
       this.onAuthenticate.accept(credential.getAccessToken());
   }
 

--- a/src/main/java/com/infisical/sdk/resources/FoldersClient.java
+++ b/src/main/java/com/infisical/sdk/resources/FoldersClient.java
@@ -1,0 +1,78 @@
+package com.infisical.sdk.resources;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.infisical.sdk.api.ApiClient;
+import com.infisical.sdk.models.*;
+import com.infisical.sdk.util.Helper;
+import com.infisical.sdk.util.InfisicalException;
+import com.infisical.sdk.util.ObjectToMapConverter;
+
+public class FoldersClient {
+  private final ApiClient httpClient;
+
+  public FoldersClient(ApiClient apiClient) {
+    this.httpClient = apiClient;
+  }
+
+  public Folder CreateFolder(CreateFolderInput input) throws InfisicalException {
+    var url = String.format("%s%s", this.httpClient.GetBaseUrl(), "/api/v1/folders");
+
+    var result = this.httpClient.post(url, input, SingleFolderResponse.class);
+
+    return result.getFolder();
+  }
+
+  public Folder GetFolder(String folderId) throws InfisicalException {
+    if(Helper.isNullOrEmpty(folderId)) {
+      throw new InfisicalException("Folder ID is required");
+    }
+
+
+    var url = String.format("%s%s", this.httpClient.GetBaseUrl(), String.format("/api/v1/folders/%s", folderId));
+    var result = this.httpClient.get(url, null, SingleFolderResponse.class);
+
+    return result.getFolder();
+  }
+
+  public List<Folder> ListFolders(ListFoldersInput input) throws InfisicalException {
+    var validationMsg = input.validate();
+
+    if (validationMsg != null) {
+      throw new InfisicalException(validationMsg);
+    }
+
+    var url = String.format("%s%s", this.httpClient.GetBaseUrl(), "/api/v1/folders");
+    var result = this.httpClient.get(url, ObjectToMapConverter.toStringMap(input), ListFoldersResponse.class);
+
+    return result.getFolders();
+  }
+
+  public Folder UpdateFolder(UpdateFolderInput input) throws InfisicalException {
+    var validationMsg = input.validate();
+
+    if (validationMsg != null) {
+      throw new InfisicalException(validationMsg);
+    }
+
+    var url = String.format("%s%s", this.httpClient.GetBaseUrl(), String.format("/api/v1/folders/%s", input.getFolderId()));
+
+    var result =  this.httpClient.patch(url, input, SingleFolderResponse.class);
+
+    return result.getFolder();
+  }
+
+  public Folder DeleteFolder(DeleteFolderInput input) throws InfisicalException {
+    var validationMsg = input.validate();
+    if (validationMsg != null) {
+      throw new InfisicalException(validationMsg);
+    }
+
+    var url = String.format("%s%s", this.httpClient.GetBaseUrl(), String.format("/api/v1/folders/%s", input.getFolderId()));
+
+    var result = this.httpClient.delete(url, input, SingleFolderResponse.class);
+
+    return result.getFolder();
+  }
+}

--- a/src/main/java/com/infisical/sdk/resources/FoldersClient.java
+++ b/src/main/java/com/infisical/sdk/resources/FoldersClient.java
@@ -16,7 +16,7 @@ public class FoldersClient {
     this.httpClient = apiClient;
   }
 
-  public Folder CreateFolder(CreateFolderInput input) throws InfisicalException {
+  public Folder Create(CreateFolderInput input) throws InfisicalException {
     var url = String.format("%s%s", this.httpClient.GetBaseUrl(), "/api/v1/folders");
 
     var result = this.httpClient.post(url, input, SingleFolderResponse.class);
@@ -24,7 +24,7 @@ public class FoldersClient {
     return result.getFolder();
   }
 
-  public Folder GetFolder(String folderId) throws InfisicalException {
+  public Folder Get(String folderId) throws InfisicalException {
     if(Helper.isNullOrEmpty(folderId)) {
       throw new InfisicalException("Folder ID is required");
     }
@@ -36,7 +36,7 @@ public class FoldersClient {
     return result.getFolder();
   }
 
-  public List<Folder> ListFolders(ListFoldersInput input) throws InfisicalException {
+  public List<Folder> List(ListFoldersInput input) throws InfisicalException {
     var validationMsg = input.validate();
 
     if (validationMsg != null) {
@@ -49,7 +49,7 @@ public class FoldersClient {
     return result.getFolders();
   }
 
-  public Folder UpdateFolder(UpdateFolderInput input) throws InfisicalException {
+  public Folder Update(UpdateFolderInput input) throws InfisicalException {
     var validationMsg = input.validate();
 
     if (validationMsg != null) {
@@ -63,7 +63,7 @@ public class FoldersClient {
     return result.getFolder();
   }
 
-  public Folder DeleteFolder(DeleteFolderInput input) throws InfisicalException {
+  public Folder Delete(DeleteFolderInput input) throws InfisicalException {
     var validationMsg = input.validate();
     if (validationMsg != null) {
       throw new InfisicalException(validationMsg);

--- a/src/main/java/com/infisical/sdk/util/Helper.java
+++ b/src/main/java/com/infisical/sdk/util/Helper.java
@@ -5,6 +5,10 @@ package com.infisical.sdk.util;
 public class Helper {
 
 
+    public static boolean isNullOrEmpty(String str) {
+        return str == null || str.trim().isEmpty();
+    }
+
 
     public static String booleanToString(Boolean b) {
         return b == null ? null : b.toString();

--- a/src/main/java/com/infisical/sdk/util/ObjectToMapConverter.java
+++ b/src/main/java/com/infisical/sdk/util/ObjectToMapConverter.java
@@ -1,0 +1,45 @@
+package com.infisical.sdk.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.google.gson.annotations.SerializedName;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ObjectToMapConverter {
+    private static final ObjectMapper objectMapper;
+
+    static {
+        objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+    }
+
+    public static Map<String, String> toStringMap(Object obj) {
+        Map<String, String> result = new HashMap<>();
+        Class<?> clazz = obj.getClass();
+
+        while (clazz != null) {
+            for (Field field : clazz.getDeclaredFields()) {
+                field.setAccessible(true);
+                try {
+                    Object value = field.get(obj);
+
+                    // Use @SerializedName if present, otherwise use field name
+                    String key = field.getName();
+                    SerializedName serializedName = field.getAnnotation(SerializedName.class);
+                    if (serializedName != null) {
+                        key = serializedName.value();
+                    }
+
+                    result.put(key, value != null ? value.toString() : null);
+                } catch (IllegalAccessException e) {
+                    // Skip inaccessible fields
+                }
+            }
+            clazz = clazz.getSuperclass();
+        }
+
+        return result;
+    }
+}


### PR DESCRIPTION
This PR adds LDAP auth support and support for folder CRUD operations. All new functions follow the builder pattern unlike the secrets resource and Universal Auth login. We will add overloads in the future to move secrets and universal auth to use the builder pattern as well.