### PR TITLE
feat: Add GCP auth login (Correctly)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
     <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-oauth2-http</artifactId>
-      <version>1.20.0</version>
+      <version>1.40.0</version>
       <optional>true</optional>
   </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-core</artifactId>
-      <version>1.5.13</version>
+      <version>1.5.19</version>
     </dependency>
 
     <dependency>
@@ -95,7 +95,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.5.13</version>
+      <version>1.5.19</version>
     </dependency>
 
     <!--    HTTP request dependencies-->

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.5.6</version>
+      <version>1.5.13</version>
     </dependency>
 
     <!--    HTTP request dependencies-->
@@ -130,6 +130,15 @@
       <version>2.34.8</version>
       <optional>true</optional>
     </dependency>
+    
+    <!--    GCP dependencies-->
+    <dependency>
+      <groupId>com.google.auth</groupId>
+      <artifactId>google-auth-library-oauth2-http</artifactId>
+      <version>1.20.0</version>
+      <optional>true</optional>
+  </dependency>
+
     <!--    Testing dependencies-->
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/src/main/java/com/infisical/sdk/auth/GCPAuthProvider.java
+++ b/src/main/java/com/infisical/sdk/auth/GCPAuthProvider.java
@@ -1,0 +1,52 @@
+package com.infisical.sdk.auth;
+
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.HashMap;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.IdTokenCredentials;
+import com.google.auth.oauth2.IdTokenProvider;
+import com.google.auth.oauth2.IdTokenProvider.Option;
+import com.infisical.sdk.util.InfisicalException;
+
+public class GCPAuthProvider {
+
+    public static HashMap<String,String> getGCPAuthInput(String identityId) throws InfisicalException{
+
+        if ( identityId == null || identityId.isEmpty() )
+
+            throw new InfisicalException( "Infisical Identity ID is required");
+
+        try{
+
+            // This will fetch credentials from environment variable named GOOGLE_APPLICATION_CREDENTIALS or
+            // or if it's running in a GCP instance it will get them from the instance itself (GCP service account attached) 
+            GoogleCredentials googleCredentials = GoogleCredentials.getApplicationDefault();
+
+            IdTokenCredentials idTokenCredentials =
+                IdTokenCredentials.newBuilder()
+                    .setIdTokenProvider((IdTokenProvider) googleCredentials)
+                    .setTargetAudience(identityId)
+                    .setOptions(Arrays.asList(Option.FORMAT_FULL, Option.LICENSES_TRUE))
+                    .build();
+    
+            // Get the ID token.
+            String idToken = idTokenCredentials.refreshAccessToken().getTokenValue();
+    
+            // Body cannot be a string so used a HashMap, you can use builder, POJO etc
+            HashMap<String, String> body =  new HashMap<>();
+              body.put("identityId", identityId);
+              body.put("jwt", idToken);
+
+            return body;
+
+        } catch (Exception e){
+            if (e.getCause() instanceof UnknownHostException) {
+                throw new InfisicalException("No network connection."); 
+            }
+            throw new InfisicalException("Failed to fetch Google credentials: " + e.getMessage());
+        }
+
+    }
+}

--- a/src/main/java/com/infisical/sdk/auth/GCPAuthProvider.java
+++ b/src/main/java/com/infisical/sdk/auth/GCPAuthProvider.java
@@ -28,7 +28,6 @@ public class GCPAuthProvider {
                 IdTokenCredentials.newBuilder()
                     .setIdTokenProvider((IdTokenProvider) googleCredentials)
                     .setTargetAudience(identityId)
-                    .setOptions(Arrays.asList(Option.FORMAT_FULL, Option.LICENSES_TRUE))
                     .build();
     
             // Get the ID token.
@@ -43,7 +42,7 @@ public class GCPAuthProvider {
 
         } catch (Exception e){
             if (e.getCause() instanceof UnknownHostException) {
-                throw new InfisicalException("No network connection."); 
+                throw new InfisicalException("Unknown Host, may be check network connection ?"); 
             }
             throw new InfisicalException("Failed to fetch Google credentials: " + e.getMessage());
         }

--- a/src/main/java/com/infisical/sdk/resources/AuthClient.java
+++ b/src/main/java/com/infisical/sdk/resources/AuthClient.java
@@ -2,6 +2,7 @@ package com.infisical.sdk.resources;
 
 import com.infisical.sdk.api.ApiClient;
 import com.infisical.sdk.auth.AwsAuthProvider;
+import com.infisical.sdk.auth.GCPAuthProvider;
 import com.infisical.sdk.models.AwsAuthLoginInput;
 import com.infisical.sdk.models.LdapAuthLoginInput;
 import com.infisical.sdk.models.MachineIdentityCredential;
@@ -52,6 +53,19 @@ public class AuthClient {
     }
 
     var url = String.format("%s%s", this.apiClient.GetBaseUrl(), "/api/v1/auth/aws-auth/login");
+    var credential = this.apiClient.post(url, input, MachineIdentityCredential.class);
+    this.onAuthenticate.accept(credential.getAccessToken());
+  }
+
+  public void GCPAuthLogin(String identityId) throws InfisicalException {
+
+    if (identityId == null || identityId.isEmpty())
+
+      throw new InfisicalException("Infisical Identity ID is required");
+
+    var url = String.format("%s%s", this.apiClient.GetBaseUrl(), "/api/v1/auth/gcp-auth/login");
+
+    var input = GCPAuthProvider.getGCPAuthInput(identityId);
     var credential = this.apiClient.post(url, input, MachineIdentityCredential.class);
     this.onAuthenticate.accept(credential.getAccessToken());
   }

--- a/src/main/java/com/infisical/sdk/resources/AuthClient.java
+++ b/src/main/java/com/infisical/sdk/resources/AuthClient.java
@@ -59,7 +59,7 @@ public class AuthClient {
 
   public void GCPAuthLogin(String identityId) throws InfisicalException {
 
-    if (identityId == null || identityId.isEmpty())
+    if (identityId == null||identityId.isEmpty())
 
       throw new InfisicalException("Infisical Identity ID is required");
 

--- a/src/test/java/com/infisical/sdk/auth/GCPAuthIntegrationTest.java
+++ b/src/test/java/com/infisical/sdk/auth/GCPAuthIntegrationTest.java
@@ -26,7 +26,7 @@ public class GCPAuthIntegrationTest {
 
             // Check if env variable machine identity is set, others are already tested via env tests
             assertNotNull(machineIdentityId, "INFISICAL_MACHINE_IDENTITY_ID env variable must be set");
-            assertFalse(machineIdentityId == "", "INFISICAL_MACHINE_IDENTITY_ID env variable must not be empty");
+assertFalse(machineIdentityId.isEmpty(), "INFISICAL_MACHINE_IDENTITY_ID env variable must not be empty");
 
 
             // Create SDK instance

--- a/src/test/java/com/infisical/sdk/auth/GCPAuthIntegrationTest.java
+++ b/src/test/java/com/infisical/sdk/auth/GCPAuthIntegrationTest.java
@@ -1,0 +1,59 @@
+package com.infisical.sdk.auth;
+
+import com.infisical.sdk.InfisicalSdk;
+import com.infisical.sdk.config.SdkConfig;
+import com.infisical.sdk.util.EnvironmentVariables;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class GCPAuthIntegrationTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(GCPAuthIntegrationTest.class);
+    @Test
+    public void testGCPAuthAndFetchSecrets() {
+
+        try {
+
+            // Load env variables
+            var envVars = new EnvironmentVariables();
+
+            // Get Machine Identity Id
+            String machineIdentityId = System.getenv("INFISICAL_MACHINE_IDENTITY_ID");
+
+
+            // Check if env variable machine identity is set, others are already tested via env tests
+            assertNotNull(machineIdentityId, "INFISICAL_MACHINE_IDENTITY_ID env variable must be set");
+            assertFalse(machineIdentityId == "", "INFISICAL_MACHINE_IDENTITY_ID env variable must not be empty");
+
+
+            // Create SDK instance
+            var sdk = new InfisicalSdk(new SdkConfig.Builder()
+                    .withSiteUrl(envVars.getSiteUrl())
+                    .build()
+            );
+
+            // Authenticate using GCP Auth
+            assertDoesNotThrow(() -> {
+                sdk.Auth().GCPAuthLogin(machineIdentityId);
+            });
+
+            // Test if we have correctly logged in and we can list the secrets
+            var secrets = sdk.Secrets().ListSecrets(
+                                    envVars.getProjectId(), 
+                                    "dev", 
+                                    "/",
+                                    null,
+                                    null,
+                                    null);
+
+            logger.info("TestGCPAuth Successful");
+            logger.info("Secrets length :  {}", secrets.size());
+
+        } catch (Exception e) {
+            throw new AssertionError(e);
+        }
+    }
+}


### PR DESCRIPTION
Description 📣
---
  
Users can now login using just one line using GCP Auth (just like AWS Auth):

```java
sdk.Auth().GCPAuthLogin(<machine-identity-id>);
```

Where **machine-identity-id** is the machine identity id with a GCP auth set up.

I have tried to keep it as close as possible to AWS Auth.

> Last time it was my first interaction with Greptile so that PR became messy, hence created a fresh one.

> I have also updated logback-classic as issues were faced as described here : https://github.com/Infisical/java-sdk/issues/12, you can reset it back.

# Demo Youtube video

https://youtu.be/fV9lB_wuZBg

Please use 2x if you feel it's a bit longer.

Please note giving the service account `Service Account Token Creator` permission is necessary.

# Type ✨
- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation


## Note
If running locally and **`not`** in a GCP instance, you need to provide it credentials via an environment variable named  **GOOGLE_APPLICATION_CREDENTIALS** created from a proper service account and the service account should have 
`Service Account Token Creator` permission to create JWT tokens. 
  
Else if running in a GCP instance it uses credentials from service account linked to the instance and you do not need to do anything in this case but in both cases the service account should have `Service Account Token Creator` permissions.

Also in both cases i.e. running in a GCP instance or locally, the "machine-identity-id" provided should have a GCP Auth setup with "Token" option selected and **`NOT`** IAM, via Infisical Dashboard and added to an Infisical project .
